### PR TITLE
Support token as first run arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target/
 !.mvn/wrapper/maven-wrapper.jar
-token.properties
 
 ### STS ###
 .apt_generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN mvn clean package -f pom.xml
 
 FROM adoptopenjdk/openjdk11
 COPY --from=MAVEN_TOOL_CHAIN /tmp/target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+# Make sure to provide an `ENV $BOT_TOKEN`
+ENTRYPOINT exec java -jar /app.jar $BOT_TOKEN

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ Discord bot base application.
 
 In order to run the application, one must first add a Discord bot token to `bot.token` in the `token.properties` file.
 Note that this file is ignored in `.gitignore`. A bot token should never be committed in git.
+
+When running directly using `java -jar` you can also directly pass your token as a first run argument. This is also the used approach in the `Dockerfile`.
+
+### Docker ###
+When running the application from the `Dockerfile` make sure to add a new `BOT_TOKEN` environment variable with the bot token as value so it can be picked up 
+in the underlying `java -jar` entrypoint command.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Discord bot base application.
 ## Usage ##
 
 In order to run the application, one must first add a Discord bot token to `bot.token` in the `token.properties` file.
-Note that this file is ignored in `.gitignore`. A bot token should never be committed in git.
+**Note that a bot token should never be committed in git!**
 
-When running directly using `java -jar` you can also directly pass your token as a first run argument. This is also the used approach in the `Dockerfile`.
+When running directly using `java -jar` you can also pass your token as a first run argument instead. This is also the used approach in the `Dockerfile`.
 
 ### Docker ###
 When running the application from the `Dockerfile` make sure to add a new `BOT_TOKEN` environment variable with the bot token as value so it can be picked up 

--- a/src/main/java/be/thibaulthelsmoortel/discordbotbase/config/DiscordBotEnvironment.java
+++ b/src/main/java/be/thibaulthelsmoortel/discordbotbase/config/DiscordBotEnvironment.java
@@ -20,9 +20,6 @@
 
 package be.thibaulthelsmoortel.discordbotbase.config;
 
-import be.thibaulthelsmoortel.discordbotbase.exceptions.MissingTokenException;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -31,7 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Thibault Helsmoortel
  */
 @ConfigurationProperties(prefix = "bot")
-public class DiscordBotEnvironment implements InitializingBean {
+public class DiscordBotEnvironment {
 
     private String token;
 
@@ -91,12 +88,5 @@ public class DiscordBotEnvironment implements InitializingBean {
 
     public void setProcessBotMessages(boolean processBotMessages) {
         this.processBotMessages = processBotMessages;
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        if (StringUtils.isBlank(token)) {
-            throw new MissingTokenException();
-        }
     }
 }

--- a/src/main/java/be/thibaulthelsmoortel/discordbotbase/exceptions/MissingTokenException.java
+++ b/src/main/java/be/thibaulthelsmoortel/discordbotbase/exceptions/MissingTokenException.java
@@ -28,6 +28,6 @@ package be.thibaulthelsmoortel.discordbotbase.exceptions;
 public class MissingTokenException extends IllegalArgumentException {
 
     public MissingTokenException() {
-        super("No token provided. Make sure to add it to token.properties.");
+        super("No token provided. Make sure to add it to token.properties or add it as the first run argument.");
     }
 }

--- a/src/test/java/be/thibaulthelsmoortel/discordbotbase/BaseTest.java
+++ b/src/test/java/be/thibaulthelsmoortel/discordbotbase/BaseTest.java
@@ -20,10 +20,8 @@
 
 package be.thibaulthelsmoortel.discordbotbase;
 
-import be.thibaulthelsmoortel.discordbotbase.config.DiscordBotEnvironment;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
@@ -32,8 +30,4 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public abstract class BaseTest {
-
-    @SuppressWarnings("unused") // Currently mocking this class is enough (provides mock token)
-    @MockBean
-    private DiscordBotEnvironment discordBotEnvironment;
 }

--- a/src/test/java/be/thibaulthelsmoortel/discordbotbase/application/DiscordBotRunnerContextUnawareTest.java
+++ b/src/test/java/be/thibaulthelsmoortel/discordbotbase/application/DiscordBotRunnerContextUnawareTest.java
@@ -4,7 +4,7 @@
  * This file is part of Discord Bot Base.
  *
  * Discord Bot Base is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ *  t under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -15,19 +15,21 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Discord Bot Base.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
-package be.thibaulthelsmoortel.discordbotbase.config;
+package be.thibaulthelsmoortel.discordbotbase.application;
 
 import static org.junit.jupiter.params.ParameterizedTest.ARGUMENTS_PLACEHOLDER;
 import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import be.thibaulthelsmoortel.discordbotbase.BaseTest;
+import be.thibaulthelsmoortel.discordbotbase.commands.core.CommandExecutor;
+import be.thibaulthelsmoortel.discordbotbase.config.DiscordBotEnvironment;
 import be.thibaulthelsmoortel.discordbotbase.exceptions.MissingTokenException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,24 +38,33 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * @author Thibault Helsmoortel
  */
-class DiscordBotEnvironmentTest extends BaseTest {
+class DiscordBotRunnerContextUnawareTest {
+
+    private DiscordBotRunner discordBotRunner;
+
+    private DiscordBotEnvironment discordBotEnvironment;
+
+    @BeforeEach
+    void setUp() {
+        this.discordBotEnvironment = mock(DiscordBotEnvironment.class);
+        this.discordBotRunner = new DiscordBotRunner(discordBotEnvironment, mock(CommandExecutor.class));
+    }
 
     @DisplayName("Should throw MissingTokenException.")
     @ParameterizedTest(name = INDEX_PLACEHOLDER + ": " + ARGUMENTS_PLACEHOLDER)
     @MethodSource("blankStrings")
     void shouldThrowMissingTokenException(String token) {
-        DiscordBotEnvironment env = new DiscordBotEnvironment();
-        env.setToken(token);
+        when(discordBotEnvironment.getToken()).thenReturn(token);
 
-        Assertions.assertThrows(MissingTokenException.class, env::afterPropertiesSet, "Exception should be thrown when no token was provided.");
+        Assertions.assertThrows(MissingTokenException.class, () -> discordBotRunner.run(), "Exception should be thrown when no token was provided.");
+        Assertions.assertThrows(MissingTokenException.class, () -> discordBotRunner.run(token), "Exception should be thrown when no token was provided.");
     }
 
     @DisplayName("Should not throw MissingTokenException.")
     @Test
     void shouldNotThrowMissingTokenException() {
-        // Mocking the object does not result in a blank token
-        DiscordBotEnvironment env = mock(DiscordBotEnvironment.class);
-        env.afterPropertiesSet();
+        when(discordBotEnvironment.getToken()).thenReturn("testToken");
+        discordBotRunner.run();
     }
 
     static Stream<String> blankStrings() {

--- a/src/test/java/be/thibaulthelsmoortel/discordbotbase/commands/AboutCommandTest.java
+++ b/src/test/java/be/thibaulthelsmoortel/discordbotbase/commands/AboutCommandTest.java
@@ -36,25 +36,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Thibault Helsmoortel
  */
 class AboutCommandTest extends BaseTest {
 
-    private final AboutCommand aboutCommand;
-
     @Mock
     private MessageReceivedEvent messageReceivedEvent;
 
     @Mock
     private MessageChannel messageChannel;
-
-    @Autowired
-    AboutCommandTest(AboutCommand aboutCommand) {
-        this.aboutCommand = aboutCommand;
-    }
 
     @BeforeEach
     void setUp() {
@@ -65,8 +57,12 @@ class AboutCommandTest extends BaseTest {
     @DisplayName("Should reply mystery.")
     @Test
     void shouldReplyMystery() {
-        aboutCommand.setEvent(messageReceivedEvent);
-        String message = (String) aboutCommand.call();
+        DiscordBotEnvironment environment = mock(DiscordBotEnvironment.class);
+        when(environment.getName()).thenReturn(null);
+        when(environment.getAuthor()).thenReturn(null);
+        AboutCommand command = new AboutCommand(environment);
+        command.setEvent(messageReceivedEvent);
+        String message = (String) command.call();
 
         Assertions.assertEquals("Mystery bot by mystery author.", message, "Message should be correct.");
 

--- a/src/test/resources/token.properties
+++ b/src/test/resources/token.properties
@@ -4,7 +4,7 @@
 # This file is part of Discord Bot Base.
 #
 # Discord Bot Base is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
+#  t under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
@@ -19,5 +19,5 @@
 #
 
 # Insert your bot token here
-# Do not commit your token!
-bot.token=
+# Do not commit your production token!
+bot.token=testToken


### PR DESCRIPTION
This is needed in order to execute the packaged jar from the command line (this is required in the Dockerfile execution, so that the token can be added as an environment variable on the docker environment and retrieved accordingly).